### PR TITLE
make clear that the alma_api_url config setting requires /bibs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You will need to have a data element in your ArchivesSpace Resources assigned to
 
 You will need to add two configuration settings to your config.rb file for these integrations to work:
 
-* **AppConfig[:alma_api_url]** represents the URL you use to access the Alma API. These are region-specific; find yours [here](https://developers.exlibrisgroup.com/alma/apis#calling).
+* **AppConfig[:alma_api_url]** represents the URL you use to access the Alma API. These are region-specific; find yours [here](https://developers.exlibrisgroup.com/alma/apis#calling). Note that since the plugin only uses the `/bibs` API, you will need to include "/bibs" at the end of the API URL string.
 * **AppConfig[:alma_apikey]** is the specific API key you use to access the Alma APIs. You may need to consult with your library IT department to access an API key to use for this plugin. If you would like to test API calls against the Alma sandbox, you may request a personal API key through the Alma Developer Network; instructions for this may be found [here](https://developers.exlibrisgroup.com/alma/apis#logging).
 
 # Using the integrations


### PR DESCRIPTION
the docs were unclear about how `alma_api_url` should be configured; making it clearer that "/bibs" should be appended to the end since it's the only Alma API the integrations use