### PR TITLE
use the controller to set the user-defined field for MMS IDs

### DIFF
--- a/frontend/controllers/alma_integrations_controller.rb
+++ b/frontend/controllers/alma_integrations_controller.rb
@@ -33,6 +33,11 @@ class AlmaIntegrationsController < ApplicationController
   	AlmaIntegrator.new(AppConfig[:alma_api_url], AppConfig[:alma_apikey])
   end
 
+  # set this to your user-defined MMS ID field
+  def mms_field
+    'string_2'
+  end
+
   def do_search(params)
   	ref = params['ref']
   	page = params['page'].nil? ? 1 : params['page'].to_i
@@ -45,10 +50,10 @@ class AlmaIntegrationsController < ApplicationController
   		'record_type' => params['record_type'],
   	}
 
-  	if json['user_defined'].nil? or json['user_defined']['string_2'].nil?
+  	if json['user_defined'].nil? or json['user_defined'][mms_field].nil?
   		results['mms'] = nil
   	else
-  		results['mms'] = json['user_defined']['string_2']
+  		results['mms'] = json['user_defined'][mms_field]
   	end
 
   	results['results'] = case params['record_type']
@@ -66,9 +71,9 @@ class AlmaIntegrationsController < ApplicationController
   def update_resource(ref, mms)
   	obj = JSONModel::HTTP.get_json(ref)
   	if obj['user_defined'].nil?
-  		obj['user_defined'] = { 'string_2' => mms }
+  		obj['user_defined'] = { mms_field => mms }
   	else
-  		obj['user_defined']['string_2'] = mms
+  		obj['user_defined'][mms_field] = mms
   	end
 
   	uri = URI("#{JSONModel::HTTP.backend_url}#{ref}")

--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -20,7 +20,7 @@ en:
       errors:
         no_marc: "No MARC record found in ArchivesSpace, search terminated"
         no_mms: "No MMS ID provided for this Resource."
-        no_record: "The MMS ID for this Resource was not found in Alma. Check that it is entered correctly in ArchivesSpace."
+        no_record: "'%{mms}' did not match any MMS ID in Alma. Check that it is entered correctly in ArchivesSpace."
       holdings:
         # populate these according to your preferred labels for holdings codes
         hscol: Hampden Center Special Collections

--- a/frontend/models/alma_integrator.rb
+++ b/frontend/models/alma_integrator.rb
@@ -36,7 +36,7 @@ class AlmaIntegrator
         xml = Nokogiri::XML(response.body,&:noblanks)
         alma['content'] = xml.at_css('record')
       else
-        alma['error'] = I18n.t("plugins.alma_integrations.errors.no_record")
+        alma['error'] = I18n.t("plugins.alma_integrations.errors.no_record", mms: mms)
       end
     end
 


### PR DESCRIPTION
uses private method `mms_field` where a user can set which of the four user-defined strings is used for MMS IDs in their instance