### PR TITLE
display Alma's error message if a get_bib request fails

### DIFF
--- a/frontend/locales/en.yml
+++ b/frontend/locales/en.yml
@@ -20,7 +20,6 @@ en:
       errors:
         no_marc: "No MARC record found in ArchivesSpace, search terminated"
         no_mms: "No MMS ID provided for this Resource."
-        no_record: "The MMS ID for this Resource was not found in Alma. Check that it is entered correctly in ArchivesSpace."
       holdings:
         # populate these according to your preferred labels for holdings codes
         hscol: Hampden Center Special Collections

--- a/frontend/models/alma_integrator.rb
+++ b/frontend/models/alma_integrator.rb
@@ -32,11 +32,11 @@ class AlmaIntegrator
       uri = URI("#{@baseurl}/#{mms}")
       uri.query = URI.encode_www_form({:apikey => @key})
       response = AlmaRequester.new.get(uri, :use_ssl => true)
+      xml = Nokogiri::XML(response.body,&:noblanks)
       if response.is_a?(Net::HTTPSuccess)
-        xml = Nokogiri::XML(response.body,&:noblanks)
         alma['content'] = xml.at_css('record')
       else
-        alma['error'] = I18n.t("plugins.alma_integrations.errors.no_record")
+        alma['error'] = "[#{xml.at_css('errorCode').text}] #{xml.at_css('errorMessage').text}"
       end
     end
 


### PR DESCRIPTION
this overrides earlier changes to AlmaIntegrator that were meant to provide more informative error messages; these are just as informative but they come from Alma