### PR TITLE
add prefix to routes.rb

### DIFF
--- a/frontend/routes.rb
+++ b/frontend/routes.rb
@@ -1,6 +1,10 @@
 ArchivesSpace::Application.routes.draw do
-  match('/plugins/alma_integrations' => 'alma_integrations#index', :via => [:get])
-  match('/plugins/alma_integrations/search' => 'alma_integrations#search', :via => [:post])
-  match('/plugins/alma_integrations/add_bibs' => 'alma_integrations#add_bibs', :via => [:post])
-  match('/plugins/alma_integrations/add_holdings' => 'alma_integrations#add_holdings', :via => [:post])
+  [AppConfig[:frontend_proxy_prefix], AppConfig[:frontend_prefix]].uniq.each do |prefix|
+    scope prefix do
+      match('/plugins/alma_integrations' => 'alma_integrations#index', :via => [:get])
+      match('/plugins/alma_integrations/search' => 'alma_integrations#search', :via => [:post])
+      match('/plugins/alma_integrations/add_bibs' => 'alma_integrations#add_bibs', :via => [:post])
+      match('/plugins/alma_integrations/add_holdings' => 'alma_integrations#add_holdings', :via => [:post])
+    end
+  end
 end


### PR DESCRIPTION
The plugin didn't work on our system because our frontend is at [url]/staff . This update to routes.rb should fix that by adding the prefix to the routes. I did a quick manual test it on our system and it works there.